### PR TITLE
feat: add find.titleBar()

### DIFF
--- a/lib/src/common_finders.dart
+++ b/lib/src/common_finders.dart
@@ -78,6 +78,14 @@ extension YaruCommonFinders on CommonFinders {
     );
   }
 
+  /// Finds [YaruTitleBar] by [text].
+  Finder titleBar(dynamic text, {bool skipOffstage = true}) {
+    return ancestor(
+      of: _textOrFinder(text, skipOffstage),
+      matching: byType(YaruTitleBar, skipOffstage: skipOffstage),
+    );
+  }
+
   /// Finds [YaruToggleButton] by [text].
   Finder toggleButton(dynamic text, {bool skipOffstage = true}) {
     return ancestor(

--- a/test/title_bar_test.dart
+++ b/test/title_bar_test.dart
@@ -1,0 +1,24 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:yaru_test/yaru_test.dart';
+import 'package:yaru_widgets/yaru_widgets.dart';
+
+import 'test_utils.dart';
+
+void main() {
+  testWidgets('find title bar', (tester) async {
+    await tester.pumpTestApp(YaruTitleBar(
+      title: const Text('title bar'),
+      actions: [
+        IconButton(
+          icon: const Icon(Icons.add),
+          onPressed: () {},
+        ),
+      ],
+    ));
+
+    expect(find.titleBar('title bar'), findsOneWidget);
+    expect(find.titleBar(find.text('title bar')), findsOneWidget);
+    expect(find.titleBar(find.byIcon(Icons.add)), findsOneWidget);
+  });
+}


### PR DESCRIPTION
A more flexible version of the extension used in [UDI](https://github.com/canonical/ubuntu-desktop-installer/blob/3767f7236d3b13030caaf7fe80e49733ee6532d1/packages/ubuntu_desktop_installer/integration_test/test_pages.dart#L641-L648)'s integration tests:
```dart
extension on CommonFinders {
  Finder title(String title) {
    return find.ancestor(
      of: find.text(title),
      matching: find.byType(YaruWindowTitleBar),
    );
  }
}
```

Release-As: 0.1.3