### PR TITLE
chore(deps): relax yaru version constraint

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
     sdk: flutter
   flutter_test:
     sdk: flutter
-  yaru: ^0.9.0
+  yaru: '>=0.9.0 <1.0.0'
   yaru_widgets: ^2.5.0
   yaru_window_platform_interface: ^0.1.0
 


### PR DESCRIPTION
Assuming there won't be any major breaking API changes in the 0.x series anymore. :)