### PR TITLE
chore(deps): Update Flutter 3.13 & Yaru

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 
 env:
-  FLUTTER_VERSION: 3.10.x
+  FLUTTER_VERSION: 3.13.x
 
 jobs:
   analyze:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,15 +6,15 @@ version: 0.1.4
 
 environment:
   sdk: '>=3.0.0 <4.0.0'
-  flutter: '>=3.10.0'
+  flutter: '>=3.13.0'
 
 dependencies:
   flutter:
     sdk: flutter
   flutter_test:
     sdk: flutter
-  yaru: '>=0.9.0 <1.0.0'
-  yaru_widgets: ^2.5.0
+  yaru: ^1.1.0
+  yaru_widgets: ^3.1.0
   yaru_window_platform_interface: ^0.1.0
 
 dev_dependencies:


### PR DESCRIPTION
CI will keep failing otherwise. Soon other repos that depend on this will fail as well.