### PR TITLE
chore: release v0.1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.1.5 (2023-10-17)
+
+## What's Changed
+* chore(deps) Update Flutter 3.13 & Yaru by @CarlosNihelton in https://github.com/ubuntu/yaru_test.dart/pull/31
+
+
+**Full Changelog**: https://github.com/ubuntu/yaru_test.dart/compare/v0.1.4...v0.1.5
+
 ## 0.1.4 (2023-08-08)
 
 ## What's Changed

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: yaru_test
 description: Provides extensions for testing Yaru applications.
 repository: https://github.com/ubuntu/yaru_test.dart
 issue_tracker: https://github.com/ubuntu/yaru_test.dart/issues
-version: 0.1.4
+version: 0.1.5
 
 environment:
   sdk: '>=3.0.0 <4.0.0'


### PR DESCRIPTION
The bot seems to have [some troubles](https://github.com/ubuntu/yaru_test.dart/actions/runs/6535564230/job/17745310065) so I'm manually bumping the version.