### PR TITLE
chore: Bump Yaru to ^6.0.0

### DIFF
--- a/lib/yaru_test.dart
+++ b/lib/yaru_test.dart
@@ -1,6 +1,3 @@
-/// Provides extensions for testing Yaru applications.
-library yaru_test;
-
 export 'src/common_finders.dart';
 export 'src/custom_matchers.dart';
 export 'src/test_window.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
     sdk: flutter
   flutter_test:
     sdk: flutter
-  yaru: ^5.0.0
+  yaru: ^6.0.0
   yaru_window_platform_interface: ^0.1.0
 
 dev_dependencies:


### PR DESCRIPTION
Upgrades Yaru to ^6.0.0 for the [latest release](https://github.com/ubuntu/yaru.dart/releases/tag/v6.0.0) released today.

---

UDENG-5691